### PR TITLE
add ALIGN after .tohost to prevent placing MMIO and data on same page

### DIFF
--- a/p/link.ld
+++ b/p/link.ld
@@ -5,7 +5,7 @@ SECTIONS
   . = 0x80000000;
   .text.init : { *(.text.init) }
   .tohost ALIGN(0x1000) : { *(.tohost) }
-  .text : { *(.text) }
+  .text ALIGN(0x1000) : { *(.text) }
   .data ALIGN(0x1000) : { *(.data) }
   .bss : { *(.bss) }
   _end = .;


### PR DESCRIPTION
This fixes tests on QEMU, since MMIO and code/data should not go on the same page.