### PR TITLE
Make vm.c sample functional and add suggested build flags

### DIFF
--- a/v/.gitignore
+++ b/v/.gitignore
@@ -1,0 +1,5 @@
+*~
+cnvmem.mem
+vm
+vm.bin
+vm.dis

--- a/v/Makefile
+++ b/v/Makefile
@@ -1,0 +1,5 @@
+vm:
+	riscv64-unknown-elf-gcc -nostdlib entry.S -g vm.c -T link.ld  -DENTROPY=0xf7930f7 -mcmodel=medany -lc -o $@
+	riscv64-unknown-elf-objdump -d vm > vm.dis
+	riscv64-unknown-elf-objcopy -I elf64-little -O binary vm vm.bin
+	riscv64-unknown-elf-objcopy -I binary -O verilog vm.bin cnvmem.mem 

--- a/v/entry.S
+++ b/v/entry.S
@@ -15,6 +15,8 @@
   .section ".text.init","ax",@progbits
   .globl _start
 _start:
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
   j handle_reset
 
   /* NMI vector */


### PR DESCRIPTION
This test does not appear to compile, and no indication is given what flags should be used. There appears to be a couple of lines missing in the header of the code, compared to similar examples. This appears to do something meaningful in the simulator and shows a degree of function under gdb, but the latter seems to get confused when virtual memory is being debugged. I would be grateful for your input as the lack of a working VM test is hampering my efforts to update my supervisor mode software to the latest Rocket release.

