### PR TITLE
Enable EXTRA_INIT macro to work in VM environment

### DIFF
--- a/v/entry.S
+++ b/v/entry.S
@@ -32,6 +32,7 @@ handle_reset:
   slli t0, t0, 12
   add sp, sp, t0
   csrw mscratch, sp
+  call extra_boot
   la a0, userstart
   j vm_boot
 

--- a/v/riscv_test.h
+++ b/v/riscv_test.h
@@ -15,6 +15,10 @@
 #undef RVTEST_CODE_BEGIN
 #define RVTEST_CODE_BEGIN                                               \
         .text;                                                          \
+        .global extra_boot;                                             \
+extra_boot:                                                             \
+        EXTRA_INIT                                                      \
+        ret;                                                            \
         .global userstart;                                              \
 userstart:                                                              \
         init


### PR DESCRIPTION
Useful for initializing things that require machine mode, such as performance counters, in individual tests.  This is especially necessary since the VM environment does not allow for tests to create their own syscalls/trap handlers.