### PR TITLE
Ecall and vector

### DIFF
--- a/encoding.h
+++ b/encoding.h
@@ -22,6 +22,7 @@
 #define MSTATUS_TVM         0x00100000
 #define MSTATUS_TW          0x00200000
 #define MSTATUS_TSR         0x00400000
+#define MSTATUS_VS          0x01800000
 #define MSTATUS32_SD        0x80000000
 #define MSTATUS_UXL         0x0000000300000000
 #define MSTATUS_SXL         0x0000000C00000000
@@ -36,6 +37,7 @@
 #define SSTATUS_XS          0x00018000
 #define SSTATUS_SUM         0x00040000
 #define SSTATUS_MXR         0x00080000
+#define SSTATUS_VS          0x01800000
 #define SSTATUS32_SD        0x80000000
 #define SSTATUS_UXL         0x0000000300000000
 #define SSTATUS64_SD        0x8000000000000000

--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -187,6 +187,8 @@ reset_vector:                                                           \
 #define RVTEST_PASS                                                     \
         fence;                                                          \
         li TESTNUM, 1;                                                  \
+        li a7, 93;                                                      \
+        li a0, 0;                                                       \
         ecall
 
 #define TESTNUM gp
@@ -195,6 +197,8 @@ reset_vector:                                                           \
 1:      beqz TESTNUM, 1b;                                               \
         sll TESTNUM, TESTNUM, 1;                                        \
         or TESTNUM, TESTNUM, 1;                                         \
+        li a7, 93;                                                      \
+        addi a0, TESTNUM, 0;                                            \
         ecall
 
 //-----------------------------------------------------------------------

--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -18,6 +18,11 @@
   RVTEST_FP_ENABLE;                                                     \
   .endm
 
+#define RVTEST_RV64UV                                                   \
+  .macro init;                                                          \
+  RVTEST_VECTOR_ENABLE;                                                 \
+  .endm
+
 #define RVTEST_RV32U                                                    \
   .macro init;                                                          \
   .endm
@@ -25,6 +30,11 @@
 #define RVTEST_RV32UF                                                   \
   .macro init;                                                          \
   RVTEST_FP_ENABLE;                                                     \
+  .endm
+
+#define RVTEST_RV32UV                                                   \
+  .macro init;                                                          \
+  RVTEST_VECTOR_ENABLE;                                                 \
   .endm
 
 #define RVTEST_RV64M                                                    \
@@ -92,6 +102,12 @@
 
 #define RVTEST_FP_ENABLE                                                \
   li a0, MSTATUS_FS & (MSTATUS_FS >> 1);                                \
+  csrs mstatus, a0;                                                     \
+  csrwi fcsr, 0
+
+#define RVTEST_VECTOR_ENABLE                                            \
+  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
+         (MSTATUS_FS & (MSTATUS_FS >> 1));                              \
   csrs mstatus, a0;                                                     \
   csrwi fcsr, 0
 


### PR DESCRIPTION
1.  keep syscall information for semihosting
2.  add new vector status defined in v0.8