### PR TITLE
Initialize frame pointer before calling C code

### DIFF
--- a/v/entry.S
+++ b/v/entry.S
@@ -37,6 +37,7 @@ handle_reset:
   csrw mscratch, sp
   call extra_boot
   la a0, userstart
+  li fp,0
   j vm_boot
 
   .globl  pop_tf


### PR DESCRIPTION
Because the C code will store this register to memory, and if it's uninitialized, it could be 64'hx in RTL simulation, and that's generally not a good idea to be storing x's to memory.