### PR TITLE
enable vector unit in V environment

### DIFF
--- a/v/riscv_test.h
+++ b/v/riscv_test.h
@@ -12,6 +12,9 @@
 #undef RVTEST_FP_ENABLE
 #define RVTEST_FP_ENABLE fssr x0
 
+#undef RVTEST_VECTOR_ENABLE
+#define RVTEST_VECTOR_ENABLE fssr x0
+
 #undef RVTEST_CODE_BEGIN
 #define RVTEST_CODE_BEGIN                                               \
         .text;                                                          \


### PR DESCRIPTION
Follow convention, undefine `RVTEST_VECTOR_ENABLE` when V environment is enable.
Otherwise, an illegal instruction exception will be raised.