### PR TITLE
fix a building error

### DIFF
--- a/v/vm.c
+++ b/v/vm.c
@@ -17,8 +17,8 @@
 void trap_entry();
 void pop_tf(trapframe_t*);
 
-volatile uint64_t tohost;
-volatile uint64_t fromhost;
+extern volatile uint64_t tohost;
+extern volatile uint64_t fromhost;
 
 static void do_tohost(uint64_t tohost_value)
 {


### PR DESCRIPTION
riscv64-unknown-elf-gcc -march=rv32g -mabi=ilp32 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -DENTROPY=0xf7930f7 -std=gnu99 -O2 -I/data/riscv/riscv-tools/riscv-tests/isa/../env/v -I/data/riscv/riscv-tools/riscv-tests/isa/macros/scalar -T/data/riscv/riscv-tools/riscv-tests/isa/../env/v/link.ld /data/riscv/riscv-tools/riscv-tests/isa/../env/v/entry.S /data/riscv/riscv-tools/riscv-tests/isa/../env/v/*.c rv32ui/simple.S -o rv32ui-v-simple
/opt/riscv/lib/gcc/riscv64-unknown-elf/10.1.0/../../../../riscv64-unknown-elf/bin/ld: /tmp/cc8oFAkO.o: in function `tohost':
(.tohost+0x0): multiple definition of `tohost'; /tmp/ccOTKaAa.o:(.sbss+0x10): first defined here
/opt/riscv/lib/gcc/riscv64-unknown-elf/10.1.0/../../../../riscv64-unknown-elf/bin/ld: /tmp/cc8oFAkO.o: in function `fromhost':
(.tohost+0x40): multiple definition of `fromhost'; /tmp/ccOTKaAa.o:(.sbss+0x8): first defined here
collect2: error: ld returned 1 exit status
/data/riscv/riscv-tools/riscv-tests/isa/Makefile:74: recipe for target 'rv32ui-v-simple' failed
make[1]: *** [rv32ui-v-simple] Error 1
make[1]: Leaving directory '/data/riscv/riscv-tools/riscv-tests/isa'
Makefile:28: recipe for target 'isa' failed
make: *** [isa] Error 2

Signed-off-by: Zhi Yong Wu <zhiyong.wu@sophgo.com>