### PR TITLE
Unconditionally clear mie register while disabling interrupts.

### DIFF
--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -115,11 +115,11 @@
 1:
 
 #define DELEGATE_NO_TRAPS                                               \
+  csrwi mie, 0;                                                         \
   la t0, 1f;                                                            \
   csrw mtvec, t0;                                                       \
   csrwi medeleg, 0;                                                     \
   csrwi mideleg, 0;                                                     \
-  csrwi mie, 0;                                                         \
   .align 2;                                                             \
 1:
 


### PR DESCRIPTION
On systems without the delegation registers, this code sequence would end up skipping the csrw to mie. The right thing to do is move it before the attempted write to the delegation registers.