### PR TITLE
Minor clang-related fixes

### DIFF
--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -110,7 +110,7 @@
 #define INIT_SATP                                                      \
   la t0, 1f;                                                            \
   csrw mtvec, t0;                                                       \
-  csrwi sptbr, 0;                                                       \
+  csrwi satp, 0;                                                       \
   .align 2;                                                             \
 1:
 

--- a/v/entry.S
+++ b/v/entry.S
@@ -153,7 +153,7 @@ trap_entry:
   STORE  t0,32*REGBYTES(sp)
   csrr   t0,sepc
   STORE  t0,33*REGBYTES(sp)
-  csrr   t0,sbadaddr
+  csrr   t0,stval
   STORE  t0,34*REGBYTES(sp)
   csrr   t0,scause
   STORE  t0,35*REGBYTES(sp)

--- a/v/vm.c
+++ b/v/vm.c
@@ -253,10 +253,10 @@ void vm_boot(uintptr_t test_addr)
 # error
 #endif
   uintptr_t vm_choice = SATP_MODE_CHOICE;
-  uintptr_t sptbr_value = ((uintptr_t)l1pt >> PGSHIFT)
+  uintptr_t satp_value = ((uintptr_t)l1pt >> PGSHIFT)
                         | (vm_choice * (SATP_MODE & ~(SATP_MODE<<1)));
-  write_csr(sptbr, sptbr_value);
-  if (read_csr(sptbr) != sptbr_value)
+  write_csr(satp, satp_value);
+  if (read_csr(satp) != satp_value)
     assert(!"unsupported satp mode");
 
   // Set up PMPs if present, ignoring illegal instruction trap if not.


### PR DESCRIPTION
This PR updates the CSRs `sptbr` and `sbadaddr` with their updated names `satp` and `stval` to support compiling with clang.