### PR TITLE
adding field badgpaddr to trapframe to get Bad GPA on guest fault traps

### DIFF
--- a/v/entry.S
+++ b/v/entry.S
@@ -157,6 +157,7 @@ trap_entry:
   STORE  t0,34*REGBYTES(sp)
   csrr   t0,scause
   STORE  t0,35*REGBYTES(sp)
+  STORE  zero,36*REGBYTES(sp) # Intializing badgpaddr to 0 for now
 
   move  a0, sp
   j handle_trap

--- a/v/riscv_test.h
+++ b/v/riscv_test.h
@@ -55,7 +55,7 @@ userstart:                                                              \
 #define PGSHIFT 12
 #define PGSIZE (1UL << PGSHIFT)
 
-#define SIZEOF_TRAPFRAME_T ((__riscv_xlen / 8) * 36)
+#define SIZEOF_TRAPFRAME_T ((__riscv_xlen / 8) * 37)
 
 #ifndef __ASSEMBLER__
 
@@ -74,6 +74,7 @@ typedef struct
   long epc;
   long badvaddr;
   long cause;
+  long badgpaddr; // For Bad GPA on guest faults
 } trapframe_t;
 #endif
 


### PR DESCRIPTION
Adding field to trap frame_t badgpaddr for storing bad GPA on guest page faults in the trap. Currently not used in this so also initializing this to zero in entry.S