### PR TITLE
Reverse memcpy direction when evicts a page.

### DIFF
--- a/v/vm.c
+++ b/v/vm.c
@@ -120,7 +120,7 @@ static void evict(unsigned long addr)
     uintptr_t sstatus = set_csr(sstatus, SSTATUS_SUM);
     if (memcmp((void*)addr, uva2kva(addr), PGSIZE)) {
       assert(user_llpt[addr/PGSIZE] & PTE_D);
-      memcpy((void*)addr, uva2kva(addr), PGSIZE);
+      memcpy(uva2kva(addr), (void*)addr, PGSIZE);
     }
     write_csr(sstatus, sstatus);
 


### PR DESCRIPTION
A possible bug in "evict" function in v/vm.c:
In line 123, when evict a dirty page in user space, memcpy should be from that page, rather than to the evicted page.