### PR TITLE
add macro for vector test to not switch to U-mode after initialization

### DIFF
--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -23,6 +23,11 @@
   RVTEST_VECTOR_ENABLE;                                                 \
   .endm
 
+#define RVTEST_RV64MV                                                   \
+  .macro init;                                                          \
+  RVTEST_MVECTOR_ENABLE;                                                 \
+  .endm
+
 #define RVTEST_RV32U                                                    \
   .macro init;                                                          \
   .endm
@@ -35,6 +40,11 @@
 #define RVTEST_RV32UV                                                   \
   .macro init;                                                          \
   RVTEST_VECTOR_ENABLE;                                                 \
+  .endm
+
+#define RVTEST_RV32MV                                                   \
+  .macro init;                                                          \
+  RVTEST_MVECTOR_ENABLE;                                                 \
   .endm
 
 #define RVTEST_RV64M                                                    \
@@ -141,6 +151,14 @@
 #define RVTEST_VECTOR_ENABLE                                            \
   li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
          (MSTATUS_FS & (MSTATUS_FS >> 1));                              \
+  csrs mstatus, a0;                                                     \
+  csrwi fcsr, 0;                                                        \
+  csrwi vcsr, 0;
+
+#define RVTEST_MVECTOR_ENABLE                                           \
+  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
+         (MSTATUS_FS & (MSTATUS_FS >> 1)) |                             \
+         (MSTATUS_MPP);                                                 \
   csrs mstatus, a0;                                                     \
   csrwi fcsr, 0;                                                        \
   csrwi vcsr, 0;


### PR DESCRIPTION
this PR is to add macro for vector test without switching to U-mode