### PR TITLE
env: trap and page fault filter mechanism

### DIFF
--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -153,6 +153,8 @@
 #define EXTRA_TVEC_MACHINE
 #define EXTRA_INIT
 #define EXTRA_INIT_TIMER
+#define FILTER_TRAP
+#define FILTER_PAGE_FAULT
 
 #define INTERRUPT_HANDLER j other_exception /* No interrupts should occur */
 

--- a/v/riscv_test.h
+++ b/v/riscv_test.h
@@ -24,6 +24,16 @@
 extra_boot:                                                             \
         EXTRA_INIT                                                      \
         ret;                                                            \
+.global trap_filter;                                                    \
+trap_filter:                                                            \
+        FILTER_TRAP                                                     \
+        li a0, 0;                                                       \
+        ret;                                                            \
+.global pf_filter;                                                      \
+pf_filter:                                                              \
+        FILTER_PAGE_FAULT                                               \
+        li a0, 0;                                                       \
+        ret;                                                            \
         .global userstart;                                              \
 userstart:                                                              \
         init


### PR DESCRIPTION
Certain tests (particularly negative) may require a fault to occur.

However in order to pass the tests, page fault and traps must return back to the tests. This patch add support for page fault and trap filtering in env.

Signed-off-by: Deepak Gupta <debug@rivosinc.com>