### PR TITLE
Fix linker script

### DIFF
--- a/p/link.ld
+++ b/p/link.ld
@@ -4,6 +4,7 @@ ENTRY(_start)
 SECTIONS
 {
   . = 0x80000000;
+  . += SIZEOF_HEADERS;
   .text.init : { *(.text.init) }
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }


### PR DESCRIPTION
Leave space for elf headers in the first PT_LOAD segment. This helps to avoid awkward phdr/ehdr handling when loading this binary in emulated environments.