### PR TITLE
Support setting V-env LFSR bits with a compiler flag

### DIFF
--- a/v/riscv_test.h
+++ b/v/riscv_test.h
@@ -59,8 +59,12 @@ userstart:                                                              \
 // Supervisor mode definitions and macros
 //-----------------------------------------------------------------------
 
-#define MAX_TEST_PAGES 63 // this must be the period of the LFSR below
-#define LFSR_NEXT(x) (((((x)^((x)>>1)) & 1) << 5) | ((x) >> 1))
+#ifndef LFSR_BITS
+#define LFSR_BITS 6
+#endif
+
+#define MAX_TEST_PAGES ((1 << LFSR_BITS)-1) // this must be the period of the LFSR below
+#define LFSR_NEXT(x) (((((x)^((x)>>1)) & 1) << (LFSR_BITS-1)) | ((x) >> 1))
 
 #define PGSHIFT 12
 #define PGSIZE (1UL << PGSHIFT)


### PR DESCRIPTION
This makes it easier to support tests with large memory footprints, as the default 63 pages may be insufficient