### PR TITLE
Use machine mode stack in V-env trap handler.

### DIFF
--- a/v/entry.S
+++ b/v/entry.S
@@ -21,10 +21,12 @@ _start:
   /* NMI vector */
   .align 2
 nmi_vector:
+  csrr sp, mscratch
   j wtf
 
   .align 2
 trap_vector:
+  csrr sp, mscratch
   j wtf
 
 handle_reset:


### PR DESCRIPTION
Machine mode trap handler does not execute properly without switching the stack pointer.