### PR TITLE
Add new macro to initialize register for vector w/o FP support

### DIFF
--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -23,6 +23,11 @@
   RVTEST_VECTOR_ENABLE;                                                 \
   .endm
 
+#define RVTEST_RV64UVX                                                  \
+  .macro init;                                                          \
+  RVTEST_ZVE32X_ENABLE;                                                 \
+  .endm
+
 #define RVTEST_RV32U                                                    \
   .macro init;                                                          \
   .endm
@@ -35,6 +40,11 @@
 #define RVTEST_RV32UV                                                   \
   .macro init;                                                          \
   RVTEST_VECTOR_ENABLE;                                                 \
+  .endm
+
+#define RVTEST_RV32UVX                                                  \
+  .macro init;                                                          \
+  RVTEST_ZVE32X_ENABLE;                                                 \
   .endm
 
 #define RVTEST_RV64M                                                    \
@@ -150,6 +160,11 @@
          (MSTATUS_FS & (MSTATUS_FS >> 1));                              \
   csrs mstatus, a0;                                                     \
   csrwi fcsr, 0;                                                        \
+  csrwi vcsr, 0;
+
+#define RVTEST_ZVE32X_ENABLE                                            \
+  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1));                              \
+  csrs mstatus, a0;                                                     \
   csrwi vcsr, 0;
 
 #define RISCV_MULTICORE_DISABLE                                         \

--- a/v/riscv_test.h
+++ b/v/riscv_test.h
@@ -17,6 +17,10 @@
   csrwi fcsr, 0;                                                        \
   csrwi vcsr, 0;
 
+#undef RVTEST_ZVE32X_ENABLE
+#define RVTEST_ZVE32X_ENABLE                                            \
+  csrwi vcsr, 0;
+
 #undef RVTEST_CODE_BEGIN
 #define RVTEST_CODE_BEGIN                                               \
         .text;                                                          \


### PR DESCRIPTION
There is no fcsr to init for a vector processor that have no FP support. This commit remove the default fcsr initialization in RVTEST_VECTOR_ENABLE macro and add a new macro RVTEST_VECTOR_FP_ENABLE to init fcsr.