### PR TITLE
Order pt writes before jumping to supervisor mode

### DIFF
--- a/v/vm.c
+++ b/v/vm.c
@@ -288,6 +288,7 @@ void vm_boot(uintptr_t test_addr)
   write_csr(satp, satp_value);
   if (read_csr(satp) != satp_value)
     assert(!"unsupported satp mode");
+  flush_page(DRAM_BASE);
 
   // Set up PMPs if present, ignoring illegal instruction trap if not.
   uintptr_t pmpc = PMP_NAPOT | PMP_R | PMP_W | PMP_X;


### PR DESCRIPTION
Although, usually, caches for in-memory memory-management data structures (e.g. TLB) are empty on reset, implicit references to such data structures, due to instruction execution, might not necessarily be ordered with respect to explicit writes. An SFENCE.VMA guarantees such ordering.

This is necessary in order to ensure that when trapping into S mode the hart sees the correct address translation mappings for supervisor level code. For user level code, the supervisor already executes an SFENCE.VMA when mapping the pages.