### PR TITLE
Fix cputchar on RV32 with virtual memory

### DIFF
--- a/v/vm.c
+++ b/v/vm.c
@@ -29,6 +29,7 @@ static void do_tohost(uint64_t tohost_value)
   tohost = tohost_value;
 }
 
+#define kaa2pa(aa) ((uintptr_t)(aa) & (uintptr_t)(~(-MEGAPAGE_SIZE)) | (uintptr_t)(DRAM_BASE))
 #define pa2kva(pa) ((void*)(pa) - DRAM_BASE - MEGAPAGE_SIZE)
 #define uva2kva(pa) ((void*)(pa) - MEGAPAGE_SIZE)
 
@@ -48,9 +49,9 @@ static void cputchar(int x)
   volatile int buff = x;
   syscall_struct[0] = SYS_write;
   syscall_struct[1] = 1;
-  syscall_struct[2] = (uintptr_t)&buff;
+  syscall_struct[2] = kaa2pa(&buff);
   syscall_struct[3] = 1;
-  do_tohost((uintptr_t)&syscall_struct);
+  do_tohost(kaa2pa(&syscall_struct));
   // Wait for response as struct has to be read by HTIF
   while(!fromhost);
 #else


### PR DESCRIPTION
When cputchar was fixed for RV32, virtual memory was not taken into consideration. If cputchar was called in supervisor mode, with virtual memory enabled, the pointers given to the HTIF would have wrongfully been virtual addresses.

Translate pointers to always be physical addresses to support cputchar with both virtual memory enabled and disabled. Defined macro kaa2pa is short for 'kernel any address to physical address'.

The fix is a bit 'hacky' since we are doing bit manipulation on pointers, but I think it's better than having to pass an argument indicating whether we are within virtual memory or not.

I missed this when I first added support for cputchar on RV32 since I only tested calling cputchar in machine mode. Oops 😵